### PR TITLE
Korrektur von Schreibfehlern

### DIFF
--- a/src/main/java/de/arstwo/twotil/Partition.java
+++ b/src/main/java/de/arstwo/twotil/Partition.java
@@ -61,7 +61,7 @@ public final class Partition<T> extends AbstractList<List<T>> {
 	/**
 	 * Returns a chunk of the partitioned content with the given index.
 	 *
-	 * @param index the chunk index of the underlaying data.
+	 * @param index the chunk index of the underlying data.
 	 * @return a list of all elements in the requested chunk.
 	 */
 	@Override

--- a/src/main/java/de/arstwo/twotil/Util.java
+++ b/src/main/java/de/arstwo/twotil/Util.java
@@ -43,7 +43,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 /**
- * Colletion of various utility functions that fit nowhere else.
+ * Collection of various utility functions that fit nowhere else.
  */
 public class Util {
 
@@ -154,7 +154,7 @@ public class Util {
 	 * Tests whether or not something is either null or contains no relevant content.
 	 * <p>
 	 * A String is blank if it contains nothing or only whitespace.<br>
-	 * A Colection is blank if it contains nothing or only blank elements.<br>
+	 * A Collection is blank if it contains nothing or only blank elements.<br>
 	 * An Array is blank if it contains nothing, or - in case of an array of Objects - all objects contained are blank. Arrays of primitive data types do not
 	 * check individual elements, as there is no definition what a blank value is for e.g. a float.
 	 */

--- a/src/main/java/de/arstwo/twotil/math/Matrix4f.java
+++ b/src/main/java/de/arstwo/twotil/math/Matrix4f.java
@@ -19,11 +19,11 @@ import java.nio.FloatBuffer;
 import java.util.Arrays;
 
 /**
- * A 3D Matrix implentation for Quaternions using floats.
+ * A 3D Matrix implementation for Quaternions using floats.
  * <p>
  * Calculations are done in place, so no additional memory is allocated by operations.
  * <p>
- * This is compatible with OpenGL and other imeplementations, which use a colum-major approach instead of the row-major that is intuitively used. This is only
+ * This is compatible with OpenGL and other implementations, which use a column-major approach instead of the row-major that is intuitively used. This is only
  * relevant if accessing the data directly. It's underlying FloatBuffer can therefore be directly inserted into OpenGL. You can use the constants below to
  * access specific data points directly.
  */
@@ -90,9 +90,9 @@ public class Matrix4f implements Cloneable {
 	/**
 	 * Sets the data of this matrix to the given external data represented in that array.
 	 * <p>
-	 * The expected format is colum-major (xx yx zx wx...)
+	 * The expected format is column-major (xx yx zx wx...)
 	 *
-	 * @param data any compatible float array that holds data flatted by column then by row.
+	 * @param data any compatible float array that holds data flattened by column then by row.
 	 * @return
 	 */
 	public Matrix4f setColumnMajor(final float[] data) {
@@ -108,9 +108,9 @@ public class Matrix4f implements Cloneable {
 	/**
 	 * Sets the data of this matrix to the given external data represented in that array, that is in a row-major format.
 	 * <p>
-	 * The internal format is colum-major (xx yx zx wx...), while the input data is row-major (xx, xy, xz, xw, ...).
+	 * The internal format is column-major (xx yx zx wx...), while the input data is row-major (xx, xy, xz, xw, ...).
 	 *
-	 * @param data any compatible float array that holds data flatted by row then by column.
+	 * @param data any compatible float array that holds data flattened by row then by column.
 	 * @return
 	 */
 	public Matrix4f setRowMajor(final float[] data) {

--- a/src/main/java/de/arstwo/twotil/math/Vector4f.java
+++ b/src/main/java/de/arstwo/twotil/math/Vector4f.java
@@ -19,14 +19,14 @@ import java.nio.FloatBuffer;
 import java.util.Arrays;
 
 /**
- * A 3D Vector implentation (Quaternion) using floats.
+ * A 3D Vector implementation (Quaternion) using floats.
  * <p>
- * Describing this as a Quaternion allows for faster tranformation in 3D space using an appropriate Matrix4f. A vector can either be a direction or a position
+ * Describing this as a Quaternion allows for faster transformation in 3D space using an appropriate Matrix4f. A vector can either be a direction or a position
  * (point in space). A direction has by definition no origin, while a position is relative to the origin at (0,0,0).
  * <p>
  * Calculations are done in place, so no additional memory is allocated by operations.
  * <p>
- * Uses a FloatBuffer which is compatible with OpenGL and similar imeplementations.
+ * Uses a FloatBuffer which is compatible with OpenGL and similar implementations.
  */
 public class Vector4f implements Cloneable {
 
@@ -195,7 +195,7 @@ public class Vector4f implements Cloneable {
 	/**
 	 * Checks if this vector is a directional vector.
 	 *
-	 * @return true if it is a directional vector, false othewise.
+	 * @return true if it is a directional vector, false otherwise.
 	 */
 	public boolean isDirection() {
 		return (this.data[W] == 0);
@@ -204,14 +204,14 @@ public class Vector4f implements Cloneable {
 	/**
 	 * Checks if this vector is a position (point in space) vector.
 	 *
-	 * @return true if it is a position vector, false othewise.
+	 * @return true if it is a position vector, false otherwise.
 	 */
 	public boolean isPosition() {
 		return (this.data[W] == 1);
 	}
 
 	/**
-	 * Sets this vector to be a direactional vector.
+	 * Sets this vector to be a directional vector.
 	 *
 	 * @return this vector.
 	 */


### PR DESCRIPTION
## Zusammenfassung
- behebt Tippfehler in `Vector4f`, `Matrix4f`, `Util` und `Partition`

## Testanweisungen
- `mvn -q test`


------
https://chatgpt.com/codex/tasks/task_e_684045cce9808328a38537614c6bf737