### PR TITLE
Fix environment and failing tests

### DIFF
--- a/src/main/java/de/arstwo/twotil/FileUtil.java
+++ b/src/main/java/de/arstwo/twotil/FileUtil.java
@@ -49,21 +49,23 @@ public class FileUtil {
 	 * <p>
 	 * Ignores directories in the zip, only files in the root directory are extracted.
 	 */
-	public static boolean unzipRootOnly(final Path source, final Path targetDir) {
-		try (final ZipInputStream zis = new ZipInputStream(Files.newInputStream(source))) {
-			ZipEntry zipEntry;
-			while ((zipEntry = zis.getNextEntry()) != null) {
-				if (!zipEntry.isDirectory()) {
-					final Path target = targetDir.resolve(zipEntry.getName());
-					Files.copy(zis, target, StandardCopyOption.REPLACE_EXISTING);
-				}
-				zis.closeEntry();
-			}
-			return true;
-		} catch (IOException e) {
-			return false;
-		}
-	}
+    public static boolean unzipRootOnly(final Path source, final Path targetDir) {
+        try (final ZipInputStream zis = new ZipInputStream(Files.newInputStream(source))) {
+            ZipEntry zipEntry;
+            while ((zipEntry = zis.getNextEntry()) != null) {
+                if (!zipEntry.isDirectory()
+                        && !zipEntry.getName().contains("/")
+                        && !zipEntry.getName().contains("\\")) {
+                    final Path target = targetDir.resolve(zipEntry.getName());
+                    Files.copy(zis, target, StandardCopyOption.REPLACE_EXISTING);
+                }
+                zis.closeEntry();
+            }
+            return true;
+        } catch (IOException e) {
+            return false;
+        }
+    }
 
 	/**
 	 * Tries to delete a given path, catches potential IOExceptions, and returns true on success, false otherwise.

--- a/src/test/java/de/arstwo/twotil/CachedNGTest.java
+++ b/src/test/java/de/arstwo/twotil/CachedNGTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024 Stefan Feldbinder <sfeldbin@googlemail.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.arstwo.twotil;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import static org.testng.Assert.*;
+import org.testng.annotations.Test;
+
+public class CachedNGTest {
+
+        @Test
+        public void testGetCachesResults() {
+                AtomicInteger counter = new AtomicInteger();
+                Cached<String, Integer> cache = new Cached<>(k -> counter.incrementAndGet());
+                assertEquals(cache.get("a"), Integer.valueOf(1));
+                assertEquals(cache.get("a"), Integer.valueOf(1));
+                assertEquals(counter.get(), 1);
+        }
+
+        @Test
+        public void testClearAndReplace() {
+                AtomicInteger counter = new AtomicInteger();
+                Cached<String, Integer> cache = new Cached<>(k -> counter.incrementAndGet());
+                assertEquals(cache.get("a"), Integer.valueOf(1));
+                cache.replace("a", 42);
+                assertEquals(cache.get("a"), Integer.valueOf(42));
+                cache.clear();
+                assertEquals(cache.get("b"), Integer.valueOf(2));
+        }
+
+        @Test
+        public void testRemoveIfAndReplaceIf() {
+                AtomicInteger counter = new AtomicInteger();
+                Cached<String, Integer> cache = new Cached<>(k -> counter.incrementAndGet());
+                assertEquals(cache.get("a"), Integer.valueOf(1));
+                cache.removeIf(e -> e.getKey().equals("a"));
+                assertEquals(cache.get("a"), Integer.valueOf(2));
+                assertTrue(cache.replaceIf("a", 2, 3));
+                assertEquals(cache.get("a"), Integer.valueOf(3));
+                assertFalse(cache.replaceIf("a", 2, 4));
+        }
+}

--- a/src/test/java/de/arstwo/twotil/FileUtilNGTest.java
+++ b/src/test/java/de/arstwo/twotil/FileUtilNGTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2024 Stefan Feldbinder <sfeldbin@googlemail.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.arstwo.twotil;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.function.Predicate;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+import static org.testng.Assert.*;
+import org.testng.annotations.Test;
+
+public class FileUtilNGTest {
+
+        @Test
+        public void testFileOlderThan() throws Exception {
+                Path f = Files.createTempFile("old", "txt");
+                Files.setLastModifiedTime(f, FileTime.from(Instant.now().minus(2, ChronoUnit.DAYS)));
+                Predicate<Path> p = FileUtil.fileOlderThan(1, ChronoUnit.DAYS);
+                assertTrue(p.test(f));
+                Files.setLastModifiedTime(f, FileTime.from(Instant.now()));
+                assertFalse(p.test(f));
+                Files.deleteIfExists(f);
+        }
+
+        @Test
+        public void testUnzipRootOnly() throws Exception {
+                Path zip = Files.createTempFile("test", ".zip");
+                try (ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(zip))) {
+                        zos.putNextEntry(new ZipEntry("a.txt"));
+                        zos.write("x".getBytes());
+                        zos.closeEntry();
+                        zos.putNextEntry(new ZipEntry("sub/b.txt"));
+                        zos.write("y".getBytes());
+                        zos.closeEntry();
+                }
+                Path target = Files.createTempDirectory("unz");
+                assertTrue(FileUtil.unzipRootOnly(zip, target));
+                assertTrue(Files.exists(target.resolve("a.txt")));
+                assertFalse(Files.exists(target.resolve("sub/b.txt")));
+                FileUtil.tryDeletePath(zip);
+                FileUtil.tryDeletePath(target.resolve("a.txt"));
+                FileUtil.tryDeletePath(target);
+        }
+
+        @Test
+        public void testTryDeletePath() throws Exception {
+                Path f = Files.createTempFile("del", "txt");
+                assertTrue(FileUtil.tryDeletePath(f));
+                assertFalse(Files.exists(f));
+                assertTrue(FileUtil.tryDeletePath(f));
+        }
+}

--- a/src/test/java/de/arstwo/twotil/GuardedNGTest.java
+++ b/src/test/java/de/arstwo/twotil/GuardedNGTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024 Stefan Feldbinder <sfeldbin@googlemail.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.arstwo.twotil;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import static org.testng.Assert.*;
+import org.testng.annotations.Test;
+
+public class GuardedNGTest {
+
+        @Test
+        public void testProcessAndAccess() {
+                Guarded<Integer> g = new Guarded<>(1);
+                assertEquals(g.process(v -> v + 1), Integer.valueOf(2));
+                AtomicBoolean called = new AtomicBoolean();
+                g.access(v -> called.set(true));
+                assertTrue(called.get());
+        }
+
+        @Test
+        public void testTryAccessWhenLocked() throws Exception {
+                Guarded<Integer> g = new Guarded<>(1);
+                Thread t = new Thread(() -> g.access(v -> {
+                        try {
+                                Thread.sleep(50);
+                        } catch (InterruptedException e) {
+                        }
+                }));
+                t.start();
+                Thread.sleep(10);
+                AtomicBoolean called = new AtomicBoolean();
+                assertFalse(g.tryAccess(v -> called.set(true)));
+                assertFalse(called.get());
+                t.join();
+                assertTrue(g.tryAccess(v -> called.set(true)));
+                assertTrue(called.get());
+        }
+}

--- a/src/test/java/de/arstwo/twotil/IntervalCheckerNGTest.java
+++ b/src/test/java/de/arstwo/twotil/IntervalCheckerNGTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024 Stefan Feldbinder <sfeldbin@googlemail.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.arstwo.twotil;
+
+import java.time.temporal.ChronoUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import static org.testng.Assert.*;
+import org.testng.annotations.Test;
+
+public class IntervalCheckerNGTest {
+
+        @Test
+        public void testUpdateAndExecute() throws Exception {
+                IntervalChecker ic = IntervalChecker.every(200, ChronoUnit.MILLIS);
+                assertTrue(ic.updateIfDue());
+                assertFalse(ic.updateIfDue());
+                Thread.sleep(250);
+                AtomicBoolean ran = new AtomicBoolean();
+                assertTrue(ic.executeIfDue(() -> ran.set(true)));
+                assertTrue(ran.get());
+                assertFalse(ic.executeIfDue(() -> ran.set(false)));
+                ic.forceChecked();
+                assertFalse(ic.updateIfDue());
+                ic.forceDue();
+                assertTrue(ic.updateIfDue());
+        }
+}

--- a/src/test/java/de/arstwo/twotil/LazyInitNGTest.java
+++ b/src/test/java/de/arstwo/twotil/LazyInitNGTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024 Stefan Feldbinder <sfeldbin@googlemail.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.arstwo.twotil;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import static org.testng.Assert.*;
+import org.testng.annotations.Test;
+
+public class LazyInitNGTest {
+
+        @Test
+        public void testInitializerRunsOnce() throws Exception {
+                AtomicInteger counter = new AtomicInteger();
+                LazyInit<Integer> lazy = new LazyInit<>(() -> counter.incrementAndGet());
+                Runnable r = () -> assertEquals(lazy.get(), Integer.valueOf(1));
+                Thread t1 = new Thread(r);
+                Thread t2 = new Thread(r);
+                t1.start();
+                t2.start();
+                t1.join();
+                t2.join();
+                assertEquals(counter.get(), 1);
+        }
+}

--- a/src/test/java/de/arstwo/twotil/PartitionNGTest.java
+++ b/src/test/java/de/arstwo/twotil/PartitionNGTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2024 Stefan Feldbinder <sfeldbin@googlemail.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.arstwo.twotil;
+
+import java.util.*;
+import static org.testng.Assert.*;
+import org.testng.annotations.Test;
+
+public class PartitionNGTest {
+
+        @Test
+        public void testPartitionSizes() {
+                Partition<Integer> p = Partition.of(Arrays.asList(0,1,2,3,4), 2);
+                assertEquals(p.size(), 3);
+                assertEquals(p.get(0), Arrays.asList(0,1));
+                assertEquals(p.get(1), Arrays.asList(2,3));
+                assertEquals(p.get(2), Arrays.asList(4));
+        }
+
+        @Test
+        public void testEmptyList() {
+                Partition<Integer> p = Partition.of(Collections.emptyList(), 3);
+                assertEquals(p.size(), 0);
+        }
+
+        @Test
+        public void testIndexOutOfBounds() {
+                Partition<Integer> p = Partition.of(Arrays.asList(1,2), 1);
+                try {
+                        p.get(3);
+                        fail("no throw");
+                } catch (IndexOutOfBoundsException e) {
+                }
+        }
+}

--- a/src/test/java/de/arstwo/twotil/PriorityThreadFactoryNGTest.java
+++ b/src/test/java/de/arstwo/twotil/PriorityThreadFactoryNGTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024 Stefan Feldbinder <sfeldbin@googlemail.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.arstwo.twotil;
+
+import static org.testng.Assert.*;
+import org.testng.annotations.Test;
+
+public class PriorityThreadFactoryNGTest {
+
+        @Test
+        public void testGroupAndPriority() {
+                PriorityThreadFactory f = new PriorityThreadFactory("prio", Thread.MAX_PRIORITY);
+                Thread t = f.newThread(() -> {});
+                assertEquals(t.getThreadGroup().getName(), "prio");
+                assertEquals(t.getThreadGroup().getMaxPriority(), Thread.MAX_PRIORITY);
+        }
+}

--- a/src/test/java/de/arstwo/twotil/UtilNGTest.java
+++ b/src/test/java/de/arstwo/twotil/UtilNGTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2024 Stefan Feldbinder <sfeldbin@googlemail.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.arstwo.twotil;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.*;
+import static org.testng.Assert.*;
+import org.testng.annotations.Test;
+
+public class UtilNGTest {
+
+        @Test
+        public void testIsBlankAndEmpty() {
+                assertTrue(Util.isBlank(""));
+                assertTrue(Util.isBlank("  "));
+                assertFalse(Util.isBlank("x"));
+                assertTrue(Util.isEmpty(new int[]{}));
+                assertFalse(Util.isEmpty(new int[]{1}));
+                assertTrue(Util.isBlank(Arrays.asList(" ")));
+        }
+
+        @Test
+        public void testJoinNonBlank() {
+                String r = Util.joinNonBlank(",", "a", " ", null, "b");
+                assertEquals(r, "a,b");
+        }
+
+        @Test
+        public void testFirstOrThrow() {
+                try {
+                        Util.firstOrThrow(Objects::nonNull, () -> new RuntimeException("fail"), null);
+                        fail("no throw");
+                } catch (RuntimeException e) {
+                }
+                assertEquals(Util.firstOrThrow(Objects::nonNull, RuntimeException::new, null, "x"), "x");
+        }
+
+        @Test
+        public void testInverseAndGroup() {
+                Map<Integer, String> map = new HashMap<>();
+                map.put(1, "a");
+                map.put(2, "a");
+                Map<String, List<Integer>> inv = Util.inverseMap(map);
+                assertEquals(inv.get("a"), Arrays.asList(1,2));
+
+                List<String> list = Arrays.asList("x","y","x");
+                Map<String, List<String>> grouped = Util.groupList(list, v -> v);
+                assertEquals(grouped.get("x"), Arrays.asList("x","x"));
+        }
+
+        @Test
+        public void testGroupListSorted() {
+                List<String> list = Arrays.asList("b","a","b");
+                Map<String, NavigableSet<String>> grouped = Util.groupListSorted(list, v -> v, Comparator.naturalOrder());
+                assertEquals(grouped.get("b").first(), "b");
+                assertEquals(grouped.get("b").size(), 1);
+        }
+
+        @Test
+        public void testCompareDates() {
+                class D { Date d; D(Date d){ this.d = d; } }
+                List<D> l = Arrays.asList(new D(Date.from(LocalDate.of(2020,1,1).atStartOfDay(ZoneId.systemDefault()).toInstant())),
+                                         new D(Date.from(LocalDate.of(2019,1,1).atStartOfDay(ZoneId.systemDefault()).toInstant())));
+                l.sort(Util.compareDatesASC(x -> x.d));
+                assertTrue(l.get(0).d.before(l.get(1).d));
+                l.sort(Util.compareDatesDESC(x -> x.d));
+                assertTrue(l.get(0).d.after(l.get(1).d));
+        }
+}

--- a/src/test/java/de/arstwo/twotil/math/MathUtilNGTest.java
+++ b/src/test/java/de/arstwo/twotil/math/MathUtilNGTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024 Stefan Feldbinder <sfeldbin@googlemail.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.arstwo.twotil.math;
+
+import static org.testng.Assert.*;
+import org.testng.annotations.Test;
+
+public class MathUtilNGTest {
+
+        @Test
+        public void testAboutEqual() {
+                assertTrue(MathUtil.aboutEqual(1.0f, 1.001f, 0.01f));
+                assertFalse(MathUtil.aboutEqual(1.0f, 1.02f, 0.01f));
+                assertTrue(MathUtil.aboutEqual(1.0, 1.0001, 0.01));
+                assertFalse(MathUtil.aboutEqual(1.0, 1.1, 0.01));
+        }
+
+        @Test
+        public void testWithinRange() {
+                assertEquals(MathUtil.withinRange(5, 0, 10), Integer.valueOf(5));
+                assertEquals(MathUtil.withinRange(-1, 0, 10), Integer.valueOf(0));
+                assertEquals(MathUtil.withinRange(11, 0, 10), Integer.valueOf(10));
+        }
+}

--- a/src/test/java/de/arstwo/twotil/math/NoiseStretchNGTest.java
+++ b/src/test/java/de/arstwo/twotil/math/NoiseStretchNGTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024 Stefan Feldbinder <sfeldbin@googlemail.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.arstwo.twotil.math;
+
+import java.util.ArrayList;
+import java.util.List;
+import static org.testng.Assert.*;
+import org.testng.annotations.Test;
+
+public class NoiseStretchNGTest {
+
+    private static class StubNoise extends SimplexNoise {
+            StubNoise() { super(new java.util.Random(0)); }
+            List<double[]> input = new ArrayList<>();
+                @Override
+                public double noise(double x, double z) { input.add(new double[]{x,z}); return 0.5; }
+                @Override
+                public double noise(double x, double y, double z) { input.add(new double[]{x,y,z}); return 0.7; }
+        }
+
+        @Test
+        public void testGetNoise2D() {
+                StubNoise s = new StubNoise();
+                NoiseStretch n = new NoiseStretch(s, 2.0, 4.0);
+                assertEquals(n.getNoise(4.0, 8.0), 0.5);
+                assertEquals(s.input.get(0)[0], 2.0);
+                assertEquals(s.input.get(0)[1], 2.0);
+        }
+
+        @Test
+        public void testGetNoise3D() {
+                StubNoise s = new StubNoise();
+                NoiseStretch n = new NoiseStretch(s, 2.0, 2.0, 2.0);
+                assertEquals(n.getNoise(4.0, 6.0, 8.0), 0.7);
+                assertEquals(s.input.get(0)[0], 2.0);
+                assertEquals(s.input.get(0)[1], 3.0);
+                assertEquals(s.input.get(0)[2], 4.0);
+        }
+}


### PR DESCRIPTION
## Summary
- allow FileUtil.unzipRootOnly to skip subdirectories
- adjust IntervalCheckerNGTest timing and order
- fix UtilNGTest to expect set size 1 and import ZoneId
- ensure NoiseStretchNGTest subclass initializes SimplexNoise

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_e_68406eb1a3a08328be23545c5957b4a7